### PR TITLE
Pagination using "will_paginate" gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "jbuilder"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.7"
+gem 'will_paginate', '~> 3.3'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    will_paginate (3.3.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.5.4)
@@ -257,6 +258,7 @@ DEPENDENCIES
   tzinfo-data (~> 1.2019, >= 1.2019.2)
   web-console
   webdrivers
+  will_paginate (~> 3.3)
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,6 +58,50 @@ body {
   font-style: italic;
 }
 
+// pagination styling
+.flickr_pagination {
+  text-align: center;
+  padding: 0.3em;
+  cursor: default; }
+
+.flickr_pagination a, .flickr_pagination span, .flickr_pagination em {
+  padding: 0.2em 0.5em; 
+  border-radius: 6px;
+}
+
+.flickr_pagination .disabled {
+  color: #aaaaaa; }
+
+.flickr_pagination .current {
+  font-style: normal;
+  font-weight: bold;
+  color: #ff0084; }
+
+.flickr_pagination a {
+  border: 1px solid whitesmoke;
+  color: #0063dc;
+  text-decoration: none; }
+
+.flickr_pagination a:hover, .flickr_pagination a:focus {
+  border-color: #003366;
+  background: #0063dc;
+  color: white; }
+
+.flickr_pagination .page_info {
+  color: #aaaaaa;
+  padding-top: 0.8em; }
+
+.flickr_pagination .previous_page, .flickr_pagination .next_page {
+  border-width: 2px; }
+
+.flickr_pagination .previous_page {
+  margin-right: 1em; }
+
+.flickr_pagination .next_page {
+  margin-left: 1em; }
+
+// end pagination
+
 // show.html.erb description
 .card-text {
   // text-align: left;

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -8,7 +8,8 @@ class ArticlesController < ApplicationController
   def index
     # needs index.html.erb
 
-    @articles = Article.all
+    # @articles = Article.all
+    @articles = Article.paginate(page: params[:page], per_page: 5)
   end
 
   # add two actions to create and new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,11 +2,13 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @articles = @user.articles
+    # @articles = @user.articles
+    @articles = @user.articles.paginate(page: params[:page], per_page: 5)
   end
 
   def index
-    @users = User.all    
+    # @users = User.all    
+    @users = User.paginate(page: params[:page], per_page: 5)
   end
 
   def new

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,7 +1,16 @@
 <h1 class="text-center mt-4">Listing All Articles</h1>
 <p class="text-center">rendering from /views/articles/index.html.erb</p>
 
+<%# <%= will_paginate @articles %> 
+<div class="flickr_pagination">
+  <%= will_paginate @articles, :container => false %>
+</div>
+
 <%= render 'article' %>
+
+<div class="flickr_pagination mb-4">
+  <%= will_paginate @articles, :container => false %>
+</div>
 
 <%# 
 <div class="container">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,9 @@
 <h1 class="text-center mt-4">Alpha Bloggers</h1>
 
+<div class="flickr_pagination">
+  <%= will_paginate @users, :container => false %>
+</div>
+
 <div class="container">
 
   <% @users.each do |user| %>
@@ -40,5 +44,10 @@
 
 </div>
 
+<div class="flickr_pagination mb-4">
+  <%= will_paginate @users, :container => false %>
+</div>
+
 <%# footer %>
 <div id="page-content"></div>
+

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,4 +8,12 @@
 
 <h3 class="text-center mt-4">Articles</h3>
 
+<div class="flickr_pagination">
+  <%= will_paginate @articles, :container => false %>
+</div>
+
 <%= render 'articles/article' %>
+
+<div class="flickr_pagination mb-4">
+  <%= will_paginate @articles, :container => false %>
+</div>


### PR DESCRIPTION
### In this branch add the `will_paginate` gem, 
 > docs and references can be found here: 
 > https://github.com/mislav/will_paginate

#### Summary:

- Installed the `will_paginate` gem to the application in order to add pagination to the articles index, users index and users show views.

- Modified the styling for the pagination based on styling examples provided by the creator of the will_paginate gem here: http://mislav.github.io/will_paginate/

- Tested out with 5 objects per page. This can be increased or decreased using the per_page argument in the actions.

![image](https://user-images.githubusercontent.com/85465559/171031167-f5ccb613-e4a6-44f6-9f17-3c1f4cb045a6.png)
